### PR TITLE
Update http_client.c

### DIFF
--- a/z3660-firmware/Z-TURN/vitis_ide/Z3660/src/lwip/http_client.c
+++ b/z3660-firmware/Z-TURN/vitis_ide/Z3660/src/lwip/http_client.c
@@ -339,6 +339,10 @@ httpc_tcp_recv(void *arg, struct altcp_pcb *pcb, struct pbuf *p, err_t r)
   }
   if ((p != NULL) && (req->parse_state == HTTPC_PARSE_RX_DATA)) {
     req->rx_content_len += p->tot_len;
+
+    // ----- RESET TIMER TICKS HERE ------
+    req->timeout_ticks = HTTPC_POLL_TIMEOUT;
+      
     if (req->recv_fn != NULL) {
       /* directly return here: the connection might already be aborted from the callback! */
       return req->recv_fn(req->callback_arg, pcb, p, r);

--- a/z3660-firmware/Z-TURN/vitis_ide/design_1_wrapper/ps7_cortexa9_0/standalone_domain/bsp/ps7_cortexa9_0/libsrc/lwip213_v1_1/src/lwip-2.1.3/src/apps/http/http_client.c
+++ b/z3660-firmware/Z-TURN/vitis_ide/design_1_wrapper/ps7_cortexa9_0/standalone_domain/bsp/ps7_cortexa9_0/libsrc/lwip213_v1_1/src/lwip-2.1.3/src/apps/http/http_client.c
@@ -337,6 +337,12 @@ httpc_tcp_recv(void *arg, struct altcp_pcb *pcb, struct pbuf *p, err_t r)
   }
   if ((p != NULL) && (req->parse_state == HTTPC_PARSE_RX_DATA)) {
     req->rx_content_len += p->tot_len;
+
+
+    // ----- RESET TIMER TICKS HERE ------
+    req->timeout_ticks = HTTPC_POLL_TIMEOUT;
+
+      
     if (req->recv_fn != NULL) {
       /* directly return here: the connection might already be aborted from the callback! */
       return req->recv_fn(req->callback_arg, pcb, p, r);


### PR DESCRIPTION
Fix as described in:
https://mail.gnu.org/archive/html/lwip-users/2021-06/msg00023.html

Fixes Issue #13 

https://github.com/shanshe/Z3660/issues/13


Changes proposed in this pull request:
   1.  resets timeout_tick, so that the file downloads without breaking the connection prematurely

