### PR TITLE
z3660: support headless firmware image builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,30 @@
 *.jou
 *.log
+*.str
+*.wdb
+*.backup
+*.tmp
+*.orig
+.Xil/
+
+# Vivado generated outputs
+z3660-firmware/Z-TURN/vivado/z3660.cache/
+z3660-firmware/Z-TURN/vivado/z3660.gen/
+z3660-firmware/Z-TURN/vivado/z3660.hw/
+z3660-firmware/Z-TURN/vivado/z3660.ip_user_files/
+z3660-firmware/Z-TURN/vivado/z3660.runs/
+z3660-firmware/Z-TURN/vivado/z3660.sim/
+z3660-firmware/Z-TURN/vivado/z3660.srcs/sources_1/bd/design_1/ip/*_imp_*/
+
+# Vitis/SDK generated outputs
+z3660-firmware/Z-TURN/vitis_ide/**/build/
+z3660-firmware/Z-TURN/vitis_ide/**/*.o
+z3660-firmware/Z-TURN/vitis_ide/**/*.d
+z3660-firmware/Z-TURN/vitis_ide/**/*.a
+z3660-firmware/Z-TURN/vitis_ide/**/*.elf
+z3660-firmware/Z-TURN/vitis_ide/**/*_ddr*.elf
+z3660-firmware/Z-TURN/vitis_ide/**/BOOT.BIN.tmp
+
 z3660-firmware/z3660_vivado/z3660/z3660.runs/
 z3660-firmware/z3660_vivado/z3660/z3660.cache/
 z3660-firmware/z3660_vivado/z3660/z3660.sdk/.metadata/.plugins/org.eclipse.core.resources/.history/
@@ -7,5 +32,4 @@ z3660-firmware/z3660_vivado/z3660/z3660.sdk/.metadata/.plugins/org.eclipse.core.
 *.d
 z3660-firmware/z3660_vivado/z3660/z3660.sdk/z3660/Debug/
 z3660-firmware/z3660_vivado/z3660/z3660.sdk/z3660/Release/
-*.str
 /.project

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: all build bootbin images fsbl z3660 z3660_emu bsp clean
+
+FIRMWARE_DIR := z3660-firmware/Z-TURN/vitis_ide
+
+all build bootbin images fsbl z3660 z3660_emu bsp clean:
+	$(MAKE) -C $(FIRMWARE_DIR) $@

--- a/z3660-firmware/Z-TURN/vitis_ide/Makefile
+++ b/z3660-firmware/Z-TURN/vitis_ide/Makefile
@@ -1,34 +1,60 @@
-# Top-level Makefile for Z3660 project on macOS using Wine bootgen
+# Top-level Makefile for Z3660 project using command line tools
 #
 # Targets:
-#   make all        -> fsbl + z3660 + z3660_emu + bootbin + version
+#   make all        -> fsbl + z3660 + z3660_emu + BOOT.BIN/Z3660.BIN/FAILSAFE.BIN
 #   make build      -> fsbl + z3660 + z3660_emu
 #   make fsbl       -> build FSBL
 #   make z3660      -> build main firmware
 #   make z3660_emu  -> build emulator firmware (core1)
-#   make bootbin    -> generate BOOT.BIN via Wine + bootgen.exe
-#   make version    -> run make_version_alfa.py packaging script
+#   make bootbin    -> generate BOOT.BIN via native bootgen or Wine bootgen.exe
+#   make images     -> generate BOOT.BIN and copy it to Z3660.BIN/FAILSAFE.BIN
 #   make clean      -> clean app builds (FSBL/app dirs)
 #
 # Configure these if needed:
-WINEPREFIX    := $(HOME)/.wine64
-export WINEPREFIX
-WINE          ?= MVK_CONFIG_LOG_LEVEL=0 WINEDEBUG=-all wine
-# Set the path to bootgen.exe on your host system (e.g., macOS or Linux).
-# Example: BOOTGEN_EXE_HOST ?= /opt/Xilinx/Vivado/2021.2/bin/bootgen.exe
-# Example: BOOTGEN_EXE_HOST ?= $(HOME)/.wine/drive_c/Xilinx/bin/bootgen.exe
-BOOTGEN_EXE_HOST := $(HOME)/.wine64/drive_c/Xilinx/bin/bootgen.exe
+JOBS          ?= 4
 
-MAKE = @make
+UNAME_S := $(shell uname -s 2>/dev/null)
 
-# Paths (Unix side)
 ifeq ($(OS),Windows_NT)
-	BIF_FILE = system.bif
+	HOST_OS := windows
+else ifeq ($(UNAME_S),Darwin)
+	HOST_OS := macos
 else
-   BIF_FILE = system_macos.bif
+	HOST_OS := linux
 endif
+
+ifeq ($(HOST_OS),linux)
+	XILINX_SDK    ?= /opt/Xilinx/SDK/2018.3
+	XILINX_VIVADO ?= /opt/Xilinx/Vivado/2018.3
+	TOOLCHAIN_BIN ?= $(XILINX_SDK)/gnu/aarch32/lin/gcc-arm-none-eabi/bin
+	BOOTGEN       ?= $(XILINX_SDK)/bin/bootgen
+	CROSS_COMPILE ?= $(TOOLCHAIN_BIN)/arm-none-eabi-
+	BOOTGEN_CMD   ?= $(BOOTGEN)
+	BIF_FILE      ?= system_cli.bif
+	export PATH := $(TOOLCHAIN_BIN):$(XILINX_SDK)/bin:$(XILINX_VIVADO)/bin:$(PATH)
+else
+	WINEPREFIX ?= $(HOME)/.wine64
+	export WINEPREFIX
+	WINE              ?= MVK_CONFIG_LOG_LEVEL=0 WINEDEBUG=-all wine
+	BOOTGEN_EXE_HOST ?= $(HOME)/.wine64/drive_c/Xilinx/bin/bootgen.exe
+	CROSS_COMPILE     ?= arm-none-eabi-
+	BOOTGEN_CMD       ?= $(WINE) $(BOOTGEN_EXE_HOST)
+	ifeq ($(HOST_OS),windows)
+		BIF_FILE ?= system.bif
+	else ifneq ($(wildcard Z3660_system/Alfa/system_macos.bif),)
+		BIF_FILE ?= system_macos.bif
+	else
+		BIF_FILE ?= system_cli.bif
+	endif
+endif
+
+# Paths
 BIF           := Z3660_system/Alfa/$(BIF_FILE)
-BOOTBIN       := Z3660_system/Alfa/sd_card/BOOT.BIN
+SDCARD_DIR    := Z3660_system/Alfa/sd_card
+BOOTBIN       := $(SDCARD_DIR)/BOOT.BIN
+BOOTBIN_TMP   := $(BOOTBIN).tmp
+Z3660BIN      := $(SDCARD_DIR)/Z3660.BIN
+FAILSAFEBIN   := $(SDCARD_DIR)/FAILSAFE.BIN
 
 # Component directories
 FSBL_DIR      := design_1_wrapper/zynq_fsbl
@@ -36,33 +62,43 @@ Z3660_DIR     := Z3660
 Z3660_EMU_DIR := Z3660_emu
 
 # Default target
-.PHONY: all build fsbl z3660 z3660_em bootbin version
-all: bootbin version
+.PHONY: all build fsbl z3660 z3660_emu bootbin images version check-tools
+all: images
 
-build: bsp fsbl z3660 z3660_emu
+build: check-tools bsp fsbl z3660 z3660_emu
+
+check-tools:
+ifeq ($(HOST_OS),linux)
+	@test -x "$(BOOTGEN)" || { echo "Missing bootgen: $(BOOTGEN)"; exit 1; }
+else
+	@command -v wine >/dev/null || { echo "Missing wine for bootgen.exe"; exit 1; }
+	@test -f "$(BOOTGEN_EXE_HOST)" || { echo "Missing bootgen.exe: $(BOOTGEN_EXE_HOST)"; exit 1; }
+endif
+	@command -v arm-none-eabi-gcc >/dev/null || { echo "Missing arm-none-eabi-gcc in PATH"; exit 1; }
+	@command -v arm-none-eabi-g++ >/dev/null || { echo "Missing arm-none-eabi-g++ in PATH"; exit 1; }
+	@test -f "$(BIF)" || { echo "Missing BIF: $(BIF)"; exit 1; }
 
 # DDR speed targets for FSBL
 fsbl_ddr533: bsp
-	$(MAKE) -C $(FSBL_DIR) DDR_SPEED=533 ddr533 -j4
+	$(MAKE) -C $(FSBL_DIR) DDR_SPEED=533 ddr533 -j$(JOBS)
 
 fsbl_ddr667: bsp
-	$(MAKE) -C $(FSBL_DIR) DDR_SPEED=667 ddr667 -j4
+	$(MAKE) -C $(FSBL_DIR) DDR_SPEED=667 ddr667 -j$(JOBS)
 
 fsbl_ddr800: bsp
-	$(MAKE) -C $(FSBL_DIR) DDR_SPEED=800 ddr800 -j4
+	$(MAKE) -C $(FSBL_DIR) DDR_SPEED=800 ddr800 -j$(JOBS)
 
 fsbl: bsp
 	$(MAKE) -C $(FSBL_DIR) DDR_SPEED=$(DDR_SPEED) clean
-	$(MAKE) -C $(FSBL_DIR) DDR_SPEED=$(DDR_SPEED) ddr$(DDR_SPEED) -j4
+	$(MAKE) -C $(FSBL_DIR) DDR_SPEED=$(DDR_SPEED) ddr$(DDR_SPEED) -j$(JOBS)
 
 z3660: bsp_cortexa9_0
-	$(MAKE) -C $(Z3660_DIR) -j4
+	$(MAKE) -C $(Z3660_DIR) CROSS_COMPILE=$(CROSS_COMPILE) -j$(JOBS)
 
 z3660_emu: bsp_cortexa9_1
-	$(MAKE) -C $(Z3660_EMU_DIR) -j4
+	$(MAKE) -C $(Z3660_EMU_DIR) CROSS_COMPILE=$(CROSS_COMPILE) -j$(JOBS)
 
-# Generate BOOT.BIN using Wine bootgen.exe
-# Uses winepath to translate Unix paths to Windows paths for bootgen.exe
+# Generate BOOT.BIN using bootgen.
 # DDR_SPEED variable can be set to 533, 667, or 800
 DDR_SPEED ?= 533
 
@@ -81,9 +117,18 @@ bootbin_prepare: build
 
 bootbin: bootbin_prepare
 	@mkdir -p $(dir $(BOOTBIN))
-	@echo "Generating BOOT.BIN via Wine bootgen.exe (DDR $(DDR_SPEED)MHz)"
-	$(WINE) $(BOOTGEN_EXE_HOST) -arch zynq -image $(BIF) -o $(BOOTBIN) -w
+	@echo "Generating BOOT.BIN via bootgen (DDR $(DDR_SPEED)MHz, $(HOST_OS), $(BIF_FILE))"
+	rm -f $(BOOTBIN_TMP)
+	$(BOOTGEN_CMD) -arch zynq -image $(BIF) -o $(BOOTBIN_TMP) -w
+	@test -s "$(BOOTBIN_TMP)" || { echo "bootgen did not create $(BOOTBIN_TMP)"; exit 1; }
+	mv $(BOOTBIN_TMP) $(BOOTBIN)
 	@echo "BOOT.BIN -> $(BOOTBIN)"
+
+images: bootbin
+	cp $(BOOTBIN) $(Z3660BIN)
+	cp $(BOOTBIN) $(FAILSAFEBIN)
+	@echo "Z3660.BIN -> $(Z3660BIN)"
+	@echo "FAILSAFE.BIN -> $(FAILSAFEBIN)"
 
 version:
 	python3 Z3660_system/make_version_alfa.py
@@ -111,4 +156,3 @@ clean:
 	-@find design_1_wrapper -name "*.a" -delete
 	-@find design_1_wrapper -name "build" -type d -exec rm -rf {} + 2>/dev/null || true
 	@echo "Clean complete"
-

--- a/z3660-firmware/Z-TURN/vitis_ide/Z3660/src/main.c
+++ b/z3660-firmware/Z-TURN/vitis_ide/Z3660/src/main.c
@@ -38,7 +38,7 @@
 #include "xil_misc_psreset_api.h"
 #include "config_file.h"
 #include "scsi/scsi.h"
-#include "LTC2990/ltc2990.h"
+#include "ltc2990/ltc2990.h"
 #include "../../Z3660_emu/src/defines.h"
 #include "ARM_ztop/slider.h"
 #include "debug_console.h"

--- a/z3660-firmware/Z-TURN/vitis_ide/Z3660_emu/src/cpu_emulator.cc
+++ b/z3660-firmware/Z-TURN/vitis_ide/Z3660_emu/src/cpu_emulator.cc
@@ -15,7 +15,7 @@ extern "C" {
 #include "memorymap.h"
 #include "uae/types.h"
 #include "sleep.h"
-#include "musashi/m68K.h"
+#include "musashi/m68k.h"
 #include <xgpiops.h>
 
 #include "m68kcpu.h"

--- a/z3660-firmware/Z-TURN/vitis_ide/Z3660_emu/src/uae/fpp_native.cc
+++ b/z3660-firmware/Z-TURN/vitis_ide/Z3660_emu/src/uae/fpp_native.cc
@@ -33,11 +33,18 @@ static const double twoto32 = 4294967296.0;
 
 static uae_u32 fpu_mode_control = 0;
 static int fpu_prec;
-#include <sys/fenv.h>
-//#define FE_TONEAREST    0x00000000
-//#define FE_TOWARDZERO   0x00C00000
-//#define FE_DOWNWARD     0x00800000
-//#define FE_UPWARD       0x00400000
+#ifndef FE_TONEAREST
+#define FE_TONEAREST    0x00000000
+#endif
+#ifndef FE_TOWARDZERO
+#define FE_TOWARDZERO   0x00C00000
+#endif
+#ifndef FE_DOWNWARD
+#define FE_DOWNWARD     0x00800000
+#endif
+#ifndef FE_UPWARD
+#define FE_UPWARD       0x00400000
+#endif
 #define FE_MASK         0x00C00000
 
 //#define debug_f1(A) printf("%lf %s %lf ",a->fp,A,b->fp)

--- a/z3660-firmware/Z-TURN/vitis_ide/Z3660_emu/src/uae/newcpu.cc
+++ b/z3660-firmware/Z-TURN/vitis_ide/Z3660_emu/src/uae/newcpu.cc
@@ -23,7 +23,9 @@
 #include "options.h"
 #include "events.h"
 #define sleep sleep2
+#define usleep usleep2
 #include <sleep.h>
+#undef usleep
 #undef sleep
 //#include "uae.h"
 #include "memory.h"

--- a/z3660-firmware/Z-TURN/vitis_ide/Z3660_system/.gitignore
+++ b/z3660-firmware/Z-TURN/vitis_ide/Z3660_system/.gitignore
@@ -1,4 +1,6 @@
-/Alfa/
+/Alfa/*
+!/Alfa/
+!/Alfa/system_cli.bif
 /Debug/
 /ReleaseAlfa/
 /Beta/

--- a/z3660-firmware/Z-TURN/vitis_ide/Z3660_system/Alfa/system_cli.bif
+++ b/z3660-firmware/Z-TURN/vitis_ide/Z3660_system/Alfa/system_cli.bif
@@ -1,0 +1,8 @@
+/* Z3660 command-line boot image */
+the_ROM_image:
+{
+  [bootloader] design_1_wrapper/zynq_fsbl/fsbl.elf
+  design_1_wrapper/hw/design_1_wrapper.bit
+  Z3660/build/ps7_cortexa9_0.elf
+  Z3660_emu/build/ps7_cortexa9_1.elf
+}


### PR DESCRIPTION
## Adds support for headless builds on Linux

Add a repo-level make target and teach the Vitis makefile to build the
FSBL, core0 firmware, core1 emulator and SD-card boot images without the
Xilinx UI.

Use native SDK 2018.3 bootgen on Linux, while preserving the existing
macOS Wine bootgen.exe flow. Add a checked-in command-line BIF for Linux
builds and copy the generated BOOT.BIN to Z3660.BIN and FAILSAFE.BIN.

Fix Linux build failures caused by case-sensitive include paths, Xilinx
sleep.h/newlib usleep conflicts and missing bare-metal FP environment
defines. Ignore generated Vivado and Vitis build outputs while allowing
the reproducible command-line BIF to be tracked.

This is an example, modify whatever you want. Please delete this line.

